### PR TITLE
Move api-gateway code to JDK21 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,8 +11,15 @@ plugins {
 group = "org.octopusden.cloud.api-gateway"
 
 java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
     withJavadocJar()
     withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 tasks.withType<GenerateModuleMetadata> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,15 +11,8 @@ plugins {
 group = "org.octopusden.cloud.api-gateway"
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
     withJavadocJar()
     withSourcesJar()
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 tasks.withType<GenerateModuleMetadata> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ val octopusGithubDockerRegistry = System.getenv().getOrDefault("OCTOPUS_GITHUB_D
 docker {
     springBootApplication {
         baseImage.set("$dockerRegistry/eclipse-temurin:21-jdk")
-        ports.set(listOf(8765, 8765))
+        ports.set(listOf(8765))
         images.set(setOf("$octopusGithubDockerRegistry/octopusden/${project.name}:${project.version}"))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ spring-cloud.version=2023.0.1
 spring-boot.version=3.2.2
 docker.registry=
 bmuschko-docker-plugin.version=9.4.0
-cloud-commons.version=2.0.7
+cloud-commons.version=2.0.14


### PR DESCRIPTION
PR для исправления багов неработающего api-gateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded cloud-commons dependency to a newer patch release for improved stability and fixes.
  * Cleaned up build configuration by removing a duplicate port entry to simplify packaging/runtime setup.
  * No direct user-facing functionality changes expected; changes affect build/runtime configuration and dependency resolution only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->