### PR TITLE
Changing behavior and work of auth

### DIFF
--- a/dev/application-dev.yml
+++ b/dev/application-dev.yml
@@ -33,7 +33,6 @@ spring:
 
 auth-server:
   url: # set via EnvFile
-  logout-url: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/logout?redirect_uri=http://localhost:${server.port}/dms-ui/
   realm: # set via EnvFile
   client-id: # set via EnvFile
   client-secret: # set via EnvFile

--- a/dev/application-dev.yml
+++ b/dev/application-dev.yml
@@ -10,19 +10,6 @@ spring:
     gateway:
       default-filters:
         - TokenRelay
-      routes:
-        - id: components-registry-service
-          uri: http://components-registry-service-production.f1.svc.cluster.local:8080
-          predicates:
-            - Path=/components-registry-service/**
-        - id: dms-getver
-          uri: http://dms-getver-production.f1.svc.cluster.local:8080
-          predicates:
-            - Path=/dms-getver/**
-        - id: dms-service
-          uri: http://dms-production.f1.svc.cluster.local:8080
-          predicates:
-            - Path=/dms-service/**
   security:
     oauth2:
       client:
@@ -45,11 +32,11 @@ spring:
             client-name: Authentication Server
 
 auth-server:
-  url: http://localhost:8180
-  logout-url: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/logout
-  realm: dev
-  client-id: api-gateway-dev
-  client-secret: secret1
+  url: # set via EnvFile
+  logout-url: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/logout?redirect_uri=http://localhost:${server.port}/dms-ui/
+  realm: # set via EnvFile
+  client-id: # set via EnvFile
+  client-secret: # set via EnvFile
 
 management:
   endpoint:

--- a/dev/application-dev.yml
+++ b/dev/application-dev.yml
@@ -10,6 +10,19 @@ spring:
     gateway:
       default-filters:
         - TokenRelay
+      routes:
+        - id: components-registry-service
+          uri: http://components-registry-service-production.f1.svc.cluster.local:8080
+          predicates:
+            - Path=/components-registry-service/**
+        - id: dms-getver
+          uri: http://dms-getver-production.f1.svc.cluster.local:8080
+          predicates:
+            - Path=/dms-getver/**
+        - id: dms-service
+          uri: http://dms-production.f1.svc.cluster.local:8080
+          predicates:
+            - Path=/dms-service/**
   security:
     oauth2:
       client:
@@ -20,15 +33,23 @@ spring:
             userinfo-uri: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/userinfo
             user-name-attribute: preferred_username
             jwk-set-uri: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/certs
+            issuer-uri: ${auth-server.url}/realms/${auth-server.realm}
         registration:
           keycloak:
             scope: openid
+            provider: keycloak
             client-id: ${auth-server.client-id}
             client-secret: ${auth-server.client-secret}
-            provider: keycloak
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-name: Authentication Server
+
+auth-server:
+  url: http://localhost:8180
+  logout-url: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/logout
+  realm: dev
+  client-id: api-gateway-dev
+  client-secret: secret1
 
 management:
   endpoint:
@@ -41,13 +62,6 @@ management:
         include: health, env, metrics, threaddump, heapdump, info, configprops, prometheus, loggers
     loggers:
       enabled: true
-
-auth-server:
-  url: # set via EnvFile
-  logout-url: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/logout?redirect_uri=http://localhost:${server.port}/dms-ui/
-  realm: # set via EnvFile
-  client-id: # set via EnvFile
-  client-secret: # set via EnvFile
 
 logging:
   level:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ spring-cloud.version=2023.0.1
 spring-boot.version=3.2.2
 docker.registry=
 bmuschko-docker-plugin.version=9.4.0
-cloud-commons.version=2.0.14
+cloud-commons.version=2.0.16

--- a/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
@@ -1,42 +1,56 @@
 package org.octopusden.cloud.apigateway.config
 
 import org.octopusden.cloud.commons.security.client.AuthServerClient
-import org.springframework.beans.factory.annotation.Value
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity.AuthorizeExchangeSpec
+import org.springframework.security.oauth2.client.oidc.web.server.logout.OidcClientInitiatedServerLogoutSuccessHandler
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler
 
 @Configuration
 @EnableWebFluxSecurity
 @Import(AuthServerClient::class)
 open class SecurityConfig(
-    @Value("\${auth-server.logout-url}")
-    private val logoutUrl: String
+    private val clientRegistrationRepository: ReactiveClientRegistrationRepository,
 ) {
     @Bean
     open fun springSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
-        http.authorizeExchange { exchanges: AuthorizeExchangeSpec ->
-            exchanges.pathMatchers("/").authenticated()
-            exchanges.anyExchange().permitAll()
-        }.oauth2Login(
-            Customizer.withDefaults()
-        ).logout { logout ->
-            logout.logoutSuccessHandler { exchange, _ ->
-                exchange.exchange.response.apply {
-                    statusCode = HttpStatus.FOUND
-                    headers.add(HttpHeaders.LOCATION, logoutUrl)
-                    cookies.remove("JSESSIONID")
-                }
-                exchange.exchange.session.flatMap { it.invalidate() }
+        http
+            .authorizeExchange { exchanges: AuthorizeExchangeSpec ->
+                exchanges
+                    .pathMatchers(
+                        "/logout/connect/back-channel/**"
+                    ).permitAll()
+                    .pathMatchers(
+                        "/"
+                    ).authenticated()
+                    .anyExchange().permitAll()
             }
-        }.csrf { it.disable() }
+            .oauth2Login(Customizer.withDefaults())
+            .logout { logout ->
+                logout.logoutSuccessHandler(oidcLogoutSuccessHandler())
+            }
+            .oidcLogout { oidcLogout ->
+                oidcLogout.backChannel {}
+            }
+            .csrf { it.disable() }
         return http.build()
+    }
+
+    private fun oidcLogoutSuccessHandler(): ServerLogoutSuccessHandler {
+        val handler = OidcClientInitiatedServerLogoutSuccessHandler(clientRegistrationRepository)
+        handler.setPostLogoutRedirectUri("{baseUrl}")
+        return handler
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(SecurityConfig::class.java)
     }
 }

--- a/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
@@ -49,8 +49,4 @@ open class SecurityConfig(
         handler.setPostLogoutRedirectUri("{baseUrl}")
         return handler
     }
-
-    companion object {
-        private val log = LoggerFactory.getLogger(SecurityConfig::class.java)
-    }
 }

--- a/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
@@ -25,9 +25,6 @@ open class SecurityConfig(
             .authorizeExchange { exchanges: AuthorizeExchangeSpec ->
                 exchanges
                     .pathMatchers(
-                        "/logout/connect/back-channel/**"
-                    ).permitAll()
-                    .pathMatchers(
                         "/"
                     ).authenticated()
                     .anyExchange().permitAll()

--- a/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/octopusden/cloud/apigateway/config/SecurityConfig.kt
@@ -1,7 +1,6 @@
 package org.octopusden.cloud.apigateway.config
 
 import org.octopusden.cloud.commons.security.client.AuthServerClient
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -38,7 +37,7 @@ open class SecurityConfig(
                 logout.logoutSuccessHandler(oidcLogoutSuccessHandler())
             }
             .oidcLogout { oidcLogout ->
-                oidcLogout.backChannel {}
+                oidcLogout.backChannel(Customizer.withDefaults())
             }
             .csrf { it.disable() }
         return http.build()


### PR DESCRIPTION
In order for the changes to work correctly, you need to add the back-channel logout parameters in your Realm client settings and disable the front channel logout 
Parameters to add:
"backchannel.logout.url": "<host>/logout/connect/back-channel/keycloak",
"backchannel.logout.session.required": "true"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated Keycloak OAuth2 provider and switched to OIDC-based logout handling.
  * Centralized auth-server settings (now provided via environment) and removed the old standalone block.
  * Management health endpoint now always shows full details.
  * Root path now requires authentication.

* **Chores**
  * Bumped cloud-commons dependency to 2.0.16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->