### PR TITLE
docs(security): document SPA-driven BFF auth pattern

### DIFF
--- a/doc/RM Services Security Model (EN).md
+++ b/doc/RM Services Security Model (EN).md
@@ -291,7 +291,7 @@ The Components Management Portal follows the same BFF pattern as DMS-UI (OAuth2 
   - **Data XHR** (`/rest/api/4/...`) goes through `frontend/src/lib/api.ts::fetchApi`. On `response.status === 401` `fetchApi` itself triggers the full-page navigation to `/oauth2/authorization/keycloak`.
   - **`/auth/me` polling** goes through `frontend/src/lib/auth.ts::fetchCurrentUser`. On 401 it returns `null` (the SPA treats the user as unauthenticated in JS land, no immediate bounce). The OIDC bounce for that signal is fired by `RequirePermission` (`frontend/src/components/RequirePermission.tsx`) via a `useEffect`, but only for permission-gated routes (`/audit`, `/admin`); on unprotected routes (`/`, `/components`, `/components/:id`) the user just sits in a degraded UI state until the next data XHR fires the bounce.
 - `frontend/src/hooks/useCurrentUser.ts` polls `/auth/me` via TanStack Query and drives the auth-state indicator in the header.
-- All XHR sets `X-Requested-With: XMLHttpRequest` as belt-and-braces, but the server gate is path-based.
+- All XHR calls set `X-Requested-With: XMLHttpRequest` as belt-and-braces, but the server gate is path-based.
 
 Because at least one of these handlers (data-XHR `fetchApi`) blindly trusts a `401` to mean "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a cross-origin `302` to Keycloak. A `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
 

--- a/doc/RM Services Security Model (EN).md
+++ b/doc/RM Services Security Model (EN).md
@@ -287,11 +287,13 @@ The Components Management Portal follows the same BFF pattern as DMS-UI (OAuth2 
 ### 1bis.3 Frontend responsibilities
 
 - The SPA never sees raw tokens; auth is a server-side session cookie + double-submit CSRF token (cookie readable by the SPA, echoed in `X-XSRF-TOKEN`).
-- `frontend/src/lib/api.ts` performs all XHR via a thin `fetchApi` wrapper. On `response.status === 401` it triggers a full-page navigation to `/oauth2/authorization/keycloak` to start a fresh OIDC flow.
-- `frontend/src/hooks/useCurrentUser.ts` calls `/auth/me` through TanStack Query; the result drives an auth-state indicator in the layout.
+- 401 is handled in two places, by call-site:
+  - **Data XHR** (`/rest/api/4/...`) goes through `frontend/src/lib/api.ts::fetchApi`. On `response.status === 401` `fetchApi` itself triggers the full-page navigation to `/oauth2/authorization/keycloak`.
+  - **`/auth/me` polling** goes through `frontend/src/lib/auth.ts::fetchCurrentUser`. On 401 it returns `null` (the SPA treats the user as unauthenticated in JS land, no immediate bounce). The OIDC bounce for that signal is fired by `RequirePermission` (`frontend/src/components/RequirePermission.tsx`) via a `useEffect`, but only for permission-gated routes (`/audit`, `/admin`); on unprotected routes (`/`, `/components`, `/components/:id`) the user just sits in a degraded UI state until the next data XHR fires the bounce.
+- `frontend/src/hooks/useCurrentUser.ts` polls `/auth/me` via TanStack Query and drives the auth-state indicator in the header.
 - All XHR sets `X-Requested-With: XMLHttpRequest` as belt-and-braces, but the server gate is path-based.
 
-Because the SPA always interprets `401` as "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a cross-origin `302` to Keycloak. A `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
+Because at least one of these handlers (data-XHR `fetchApi`) blindly trusts a `401` to mean "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a cross-origin `302` to Keycloak. A `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
 
 ### 1bis.4 Backend responsibilities
 
@@ -355,8 +357,11 @@ class ApiClientAuthorizationFailureFilter(
 
 Starting state: user is logged in, the portal session is valid, but the OAuth2 refresh attempt fails (Keycloak SSO session gone, refresh token expired, etc.).
 
-- **Browser navigation** to `/components`: the SPA bootstrap loads, eventually the chain raises `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` sees a non-API path and re-emits, `OAuth2AuthorizationRequestRedirectWebFilter` sends a full-page `302` to OIDC → fresh Keycloak login → user lands back where they started. Same UX as DMS-UI.
-- **XHR** to `/rest/api/4/components` or `/auth/me`: `TokenRelay` raises the exception inside the reactive chain, `ApiClientAuthorizationFailureFilter` matches the path and writes a JSON `401`, the SPA's `api.ts` 401-handler does `window.location.assign('/oauth2/authorization/keycloak')` from JS, the user lands on a fresh OIDC flow at the top level. **No CORS error, no `Failed to fetch`.**
+- **Browser navigation to a SPA path** (`/`, `/components`, `/components/:id`, etc.): SCG `TokenRelay` only runs on the routed paths (`/rest/**`, `/auth/**`), so navigating to a SPA path never reaches the place where `ClientAuthorizationRequiredException` is raised — the portal session cookie is still valid, the security chain accepts the request, and the SPA shell is served (`200 OK` from `SpaFallbackFilter`). The user notices nothing until the SPA boots and starts XHR.
+- **Data XHR** (`/rest/api/4/components`, `/rest/api/4/owners`, etc.): `TokenRelay` raises `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` matches the path and writes JSON `401`, `api.ts::fetchApi` sees the 401 and immediately does `window.location.assign('/oauth2/authorization/keycloak')` from JS — the user lands on a fresh OIDC flow at the top level. **No CORS error, no `Failed to fetch`.**
+- **`/auth/me` polling**: same backend path — JSON `401` from the filter — but `auth.ts::fetchCurrentUser` treats 401 as "logged out" and returns `null` instead of bouncing. On a permission-gated route (`/audit`, `/admin`) `RequirePermission` then fires the same `window.location.assign(...)` from a `useEffect` once it sees `user == null`. On unprotected routes (`/components` etc.) the bounce is initiated by whichever data XHR fires next — typically a TanStack Query refetch within seconds.
+
+The filter's `else Mono.error(ex)` branch (rethrow for non-API paths) is there as defensive correctness — if some future filter chain ever raises `ClientAuthorizationRequiredException` for a non-routed path, browser navigations should still get the default 302 to OIDC. In this BFF as configured today the rethrow branch is not exercised by production traffic, because TokenRelay is the only origin of that exception and only runs on `/rest/**` and `/auth/**`.
 
 ## 2. Api-Gateway service
 
@@ -1282,9 +1287,9 @@ For full-page navigation, perfect — the browser shows the login form. For an X
 
 DMS-UI and `api-gateway` technically have the same gap, but it is invisible to their users:
 
-- DMS-UI's frontend currently only shows an error toast on failed XHR; users hit refresh, the top-level GET to `/` triggers the `302`, full-page Keycloak login, all good. Less polished but not broken.
+- DMS-UI's frontend only shows an error toast on failed XHR; the user has no automatic recovery path. Recovery happens incidentally — explicit logout, the Spring session timing out and then the next request 302-ing as anonymous, or tab close — none of which is presented to the user as "do this now". Less polished but not actively broken because no SPA component depends on a periodic XHR succeeding.
 - `api-gateway` only serves HTML navigation pages, no XHR, so the failure mode never occurs.
 
-For an SPA-driven BFF this is not acceptable. The Components Management Portal solves it with the pattern documented in section 1bis: a path-aware authentication entry point + an inner `WebFilter` that intercepts `ClientAuthorizationRequiredException` for API/XHR paths and converts it to a JSON `401`, which the SPA's `api.ts` 401-handler turns into a top-level navigation to `/oauth2/authorization/keycloak`. Browser navigations on the same BFF still get the default `302`, so the legitimate full-page flow is unchanged.
+For an SPA-driven BFF this is not acceptable. The Components Management Portal solves it with the pattern documented in section 1bis: a path-aware authentication entry point + an inner `WebFilter` that intercepts `ClientAuthorizationRequiredException` for API/XHR paths and converts it to a JSON `401`. The SPA then bounces from JS — `api.ts::fetchApi` does it directly for data XHR, `auth.ts::fetchCurrentUser` returns `null` and lets `RequirePermission` (or the next data XHR) trigger the bounce on `/auth/me` polling — landing the user on a fresh top-level OIDC flow. Browser navigations on the same BFF still get the default `302` from the un-touched anonymous entry point, so the legitimate full-page flow for unauthenticated users is unchanged.
 
 If DMS-UI ever gains SPA-style XHR polling, the same pattern should be backported.

--- a/doc/RM Services Security Model (EN).md
+++ b/doc/RM Services Security Model (EN).md
@@ -8,6 +8,13 @@
    3. Frontend responsibilities
    4. Backend responsibilities
    5. User flow with code examples
+1bis. `Components Management Portal` service (BFF for SPA with XHR-aware auth)
+   1. Versions
+   2. Description
+   3. Frontend responsibilities
+   4. Backend responsibilities
+   5. Why an extra filter is required
+   6. User flow on token refresh failure
 2. `Api-Gateway` service
    1. Versions
    2. Description
@@ -20,6 +27,7 @@
    4. How the library is connected and used in other services
 4. Q&A
    1. Why logging out in `dms-ui` also logs out `api-gateway`, and vice versa
+   2. Why a SPA-driven BFF cannot use the same simple `oauth2Login` as DMS-UI
 
 ![](communication_diagram.png)
 
@@ -96,6 +104,8 @@ Repository: `https://github.com/octopusden/octopus-dms-ui`
 // Disable Cross-Origin Resource Sharing (CORS)
 .csrf { it.disable() }
 ```
+
+> **Note**: this minimal config relies on full-page OIDC redirect being the only auth-failure mode. For BFFs serving SPA XHR (see section 1bis), an extra `ClientAuthorizationRequiredException` interceptor is required — otherwise an authenticated session whose token cannot be refreshed produces a cross-origin 302 to Keycloak that silently CORS-fails the XHR.
 
 ### 1.5 User flow with code examples
 
@@ -255,6 +265,98 @@ QA redirect:
 ```yaml
 dms-ui.hostname: <host_name>
 ```
+
+## 1bis. Components Management Portal service (BFF for SPA with XHR-aware auth)
+
+Repository: `https://github.com/octopusden/octopus-components-management-portal`
+
+The Components Management Portal follows the same BFF pattern as DMS-UI (OAuth2 login, server-side session, `TokenRelay` proxying to a downstream service — Components Registry Service in this case). The difference is on the frontend side: the portal SPA does periodic XHR `/auth/me` polling and background data refetches with the assumption that an expired session yields a **JSON 401** (not a `302` to OIDC). That assumption shapes the backend.
+
+### 1bis.1 Versions
+
+- JDK 21
+- Kotlin 1.9.25
+- Gradle 8.14.4
+- Spring Boot 3.2.2
+- Spring Cloud 2023.0.1
+
+### 1bis.2 Description
+
+`octopus-components-management-portal` is a Spring Boot WebFlux + Spring Cloud Gateway BFF that authenticates the browser via OIDC, stores the access token in the server-side session, and `TokenRelay`-forwards it as `Authorization: Bearer <token>` when proxying `/rest/**` and `/auth/**` to the registry service. It also serves a Vite-built React SPA from `/static/`.
+
+### 1bis.3 Frontend responsibilities
+
+- The SPA never sees raw tokens; auth is a server-side session cookie + double-submit CSRF token (cookie readable by the SPA, echoed in `X-XSRF-TOKEN`).
+- `frontend/src/lib/api.ts` performs all XHR via a thin `fetchApi` wrapper. On `response.status === 401` it triggers a full-page navigation to `/oauth2/authorization/keycloak` to start a fresh OIDC flow.
+- `frontend/src/hooks/useCurrentUser.ts` calls `/auth/me` through TanStack Query; the result drives an auth-state indicator in the layout.
+- All XHR sets `X-Requested-With: XMLHttpRequest` as belt-and-braces, but the server gate is path-based.
+
+Because the SPA always interprets `401` as "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a cross-origin `302` to Keycloak. A `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
+
+### 1bis.4 Backend responsibilities
+
+`SecurityConfig.kt` splits the auth entry point so API/XHR callers and browser navigations get different responses to the same "unauthenticated" condition:
+
+```kotlin
+val apiMatcher: ServerWebExchangeMatcher = pathMatchers("/rest/**", "/auth/**")
+val apiEntryPoint =
+    ServerAuthenticationEntryPoint { exchange, _ ->
+        apiJson401Writer.write(exchange, ApiJson401Reason.UNAUTHENTICATED)
+    }
+val browserEntryPoint =
+    RedirectServerAuthenticationEntryPoint("/oauth2/authorization/$OIDC_REGISTRATION_ID")
+val delegatingEntryPoint =
+    DelegatingServerAuthenticationEntryPoint(
+        DelegateEntry(apiMatcher, apiEntryPoint),
+        DelegateEntry(ServerWebExchangeMatchers.anyExchange(), browserEntryPoint),
+    )
+
+http
+    .authorizeExchange { /* ... */ }
+    .oauth2Login(Customizer.withDefaults())
+    .exceptionHandling { it.authenticationEntryPoint(delegatingEntryPoint) }
+    // see 1bis.5 below for why this filter is required
+    .addFilterAfter(
+        ApiClientAuthorizationFailureFilter(apiMatcher, apiJson401Writer),
+        SecurityWebFiltersOrder.OAUTH2_AUTHORIZATION_CODE,
+    )
+    /* ... */
+```
+
+`ApiJson401Writer` is a shared `@Component` that writes a fixed-shape JSON 401 envelope (`{"error":"<reason>"}`) where the reason text comes from a `ApiJson401Reason` enum — never from arbitrary exception messages. Both the entry point and the filter (see below) route through it, so anonymous and refresh-failed paths are indistinguishable to the client.
+
+### 1bis.5 Why an extra filter is required
+
+The `DelegatingServerAuthenticationEntryPoint` covers the "unauthenticated request" case correctly. It does **not** cover the case where the user *is* authenticated (valid session, valid `OAuth2AuthenticationToken`) but the OAuth2 access token cannot be refreshed — for example because the SSO session was killed by a logout from a sibling client (see Q&A 4.1).
+
+That failure surfaces from Spring Cloud Gateway's `TokenRelayGatewayFilterFactory` as a `ClientAuthorizationRequiredException`. By default this exception is caught by `OAuth2AuthorizationRequestRedirectWebFilter` (registered by `oauth2Login()` at `SecurityWebFiltersOrder.HTTP_BASIC`) which sends a `302` to `/oauth2/authorization/keycloak`. For browser navigation that is the right UX. For an XHR call it is the bug described in 1bis.3 — the browser silently follows the redirect, hits Keycloak's cross-origin preflight, and the XHR fails with a CORS error.
+
+`ApiClientAuthorizationFailureFilter` intercepts that exception for `/rest/**` + `/auth/**` paths and routes through `ApiJson401Writer`. It must sit INNER of `OAuth2AuthorizationRequestRedirectWebFilter` so the exception bubbles up through it first; that is what `addFilterAfter(filter, SecurityWebFiltersOrder.OAUTH2_AUTHORIZATION_CODE)` achieves — "after" places the filter at a higher order and therefore deeper in the chain.
+
+```kotlin
+class ApiClientAuthorizationFailureFilter(
+    private val apiMatcher: ServerWebExchangeMatcher,
+    private val writer: ApiJson401Writer,
+) : WebFilter {
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        chain.filter(exchange).onErrorResume(ClientAuthorizationRequiredException::class.java) { ex ->
+            apiMatcher.matches(exchange).flatMap { match ->
+                if (match.isMatch) {
+                    writer.write(exchange, ApiJson401Reason.AUTHORIZATION_EXPIRED)
+                } else {
+                    Mono.error(ex)  // re-emit so the default redirect filter still handles browser navigations
+                }
+            }
+        }
+}
+```
+
+### 1bis.6 User flow on token refresh failure
+
+Starting state: user is logged in, the portal session is valid, but the OAuth2 refresh attempt fails (Keycloak SSO session gone, refresh token expired, etc.).
+
+- **Browser navigation** to `/components`: the SPA bootstrap loads, eventually the chain raises `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` sees a non-API path and re-emits, `OAuth2AuthorizationRequestRedirectWebFilter` sends a full-page `302` to OIDC → fresh Keycloak login → user lands back where they started. Same UX as DMS-UI.
+- **XHR** to `/rest/api/4/components` or `/auth/me`: `TokenRelay` raises the exception inside the reactive chain, `ApiClientAuthorizationFailureFilter` matches the path and writes a JSON `401`, the SPA's `api.ts` 401-handler does `window.location.assign('/oauth2/authorization/keycloak')` from JS, the user lands on a fresh OIDC flow at the top level. **No CORS error, no `Failed to fetch`.**
 
 ## 2. Api-Gateway service
 
@@ -1164,3 +1266,25 @@ Spring Security does not synchronize logout across applications automatically, s
 - on a repeated OAuth2 login
 
 In other words, logging out in one client does not revoke access tokens that were already issued to other clients. They remain valid for Spring until they expire, but they cannot be refreshed without a new SSO session.
+
+### 4.2 Why a SPA-driven BFF cannot use the same simple `oauth2Login` as DMS-UI
+
+When a BFF only serves full-page navigations (DMS-UI today, `api-gateway` always), `oauth2Login(Customizer.withDefaults())` is enough: every auth failure becomes a `302` to the OIDC authorization endpoint, and the browser handles it as a regular top-level navigation — Keycloak's login form renders, the user signs in, and Spring Security's authorization-code filter completes the flow.
+
+The picture changes once the BFF starts serving an SPA that relies on background XHR for `/auth/me` polling and data refetches (the Components Management Portal pattern — see section 1bis). After idle time, an authenticated session whose token cannot be refreshed (typically because the SSO session was killed by a logout from a sibling client — see 4.1) raises `ClientAuthorizationRequiredException` in `TokenRelayGatewayFilterFactory`. Default Spring Security behaviour: `OAuth2AuthorizationRequestRedirectWebFilter` catches it and returns `302 Location: <Keycloak>/realms/.../protocol/openid-connect/auth?response_type=code&...`.
+
+For full-page navigation, perfect — the browser shows the login form. For an XHR call, broken:
+
+1. `fetch()` defaults to `redirect: 'follow'`, so the browser silently follows the cross-origin redirect to Keycloak.
+2. The cross-origin XHR triggers a CORS preflight (`OPTIONS`) on the Keycloak host.
+3. Keycloak's authorization endpoint is not designed for XHR and does not return permissive CORS headers for our origin — even if it did, its response is an HTML form, not JSON.
+4. The preflight is rejected → the original `fetch` rejects with `TypeError: Failed to fetch` → the SPA shows a generic error and the user is stuck.
+
+DMS-UI and `api-gateway` technically have the same gap, but it is invisible to their users:
+
+- DMS-UI's frontend currently only shows an error toast on failed XHR; users hit refresh, the top-level GET to `/` triggers the `302`, full-page Keycloak login, all good. Less polished but not broken.
+- `api-gateway` only serves HTML navigation pages, no XHR, so the failure mode never occurs.
+
+For an SPA-driven BFF this is not acceptable. The Components Management Portal solves it with the pattern documented in section 1bis: a path-aware authentication entry point + an inner `WebFilter` that intercepts `ClientAuthorizationRequiredException` for API/XHR paths and converts it to a JSON `401`, which the SPA's `api.ts` 401-handler turns into a top-level navigation to `/oauth2/authorization/keycloak`. Browser navigations on the same BFF still get the default `302`, so the legitimate full-page flow is unchanged.
+
+If DMS-UI ever gains SPA-style XHR polling, the same pattern should be backported.

--- a/doc/RM Services Security Model (EN).md
+++ b/doc/RM Services Security Model (EN).md
@@ -105,7 +105,7 @@ Repository: `https://github.com/octopusden/octopus-dms-ui`
 .csrf { it.disable() }
 ```
 
-> **Note**: this minimal config relies on full-page OIDC redirect being the only auth-failure mode. For BFFs serving SPA XHR (see section 1bis), an extra `ClientAuthorizationRequiredException` interceptor is required — otherwise an authenticated session whose token cannot be refreshed produces a cross-origin 302 to Keycloak that silently CORS-fails the XHR.
+> **Note**: this minimal config relies on full-page OIDC redirect being the only auth-failure mode. For BFFs serving SPA XHR (see section 1bis), a path-aware authentication entry point and an inner `ClientAuthorizationRequiredException` filter are required — otherwise an unauthenticated XHR, or an authenticated session whose token cannot be refreshed, produces a 302 to Keycloak that `fetch()` follows cross-origin and silently CORS-fails.
 
 ### 1.5 User flow with code examples
 
@@ -293,7 +293,7 @@ The Components Management Portal follows the same BFF pattern as DMS-UI (OAuth2 
 - `frontend/src/hooks/useCurrentUser.ts` polls `/auth/me` via TanStack Query and drives the auth-state indicator in the header.
 - All XHR calls set `X-Requested-With: XMLHttpRequest` as belt-and-braces, but the server gate is path-based.
 
-Because at least one of these handlers (data-XHR `fetchApi`) blindly trusts a `401` to mean "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a cross-origin `302` to Keycloak. A `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
+Because at least one of these handlers (data-XHR `fetchApi`) blindly trusts a `401` to mean "session expired, do a full-page bounce", the backend **must** return JSON `401` for XHR — never a `302` whose Location is cross-origin to Keycloak. Such a `302` would be silently followed by `fetch` (default `redirect: 'follow'`), the cross-origin Keycloak preflight would CORS-fail, and the XHR would reject with `TypeError: Failed to fetch`.
 
 ### 1bis.4 Backend responsibilities
 

--- a/doc/RM Services Security Model (RU).md
+++ b/doc/RM Services Security Model (RU).md
@@ -287,11 +287,13 @@ Repository: `https://github.com/octopusden/octopus-components-management-portal`
 ### 1bis.3 За что отвечает frontend
 
 - SPA не видит сырых токенов; аутентификация — серверная session cookie + double-submit CSRF (cookie доступна SPA, отдаётся обратно в `X-XSRF-TOKEN`).
-- `frontend/src/lib/api.ts` отправляет все XHR через тонкий wrapper `fetchApi`. На `response.status === 401` инициирует full-page navigation на `/oauth2/authorization/keycloak` для свежего OIDC-флоу.
-- `frontend/src/hooks/useCurrentUser.ts` дёргает `/auth/me` через TanStack Query; результат рисует индикатор статуса аутентификации в шапке.
+- 401 обрабатывается в двух разных местах, в зависимости от call-site:
+  - **Data XHR** (`/rest/api/4/...`) идёт через `frontend/src/lib/api.ts::fetchApi`. На `response.status === 401` сам `fetchApi` инициирует full-page navigation на `/oauth2/authorization/keycloak`.
+  - **`/auth/me`-поллинг** идёт через `frontend/src/lib/auth.ts::fetchCurrentUser`. На 401 он возвращает `null` (SPA трактует пользователя как unauthenticated в JS-land, без немедленного bounce'а). OIDC-bounce на этот сигнал отправляет `RequirePermission` (`frontend/src/components/RequirePermission.tsx`) через `useEffect`, но только для permission-gated роутов (`/audit`, `/admin`); на незащищённых роутах (`/`, `/components`, `/components/:id`) пользователь просто сидит в degraded UI до момента, когда следующий data XHR инициирует bounce.
+- `frontend/src/hooks/useCurrentUser.ts` поллит `/auth/me` через TanStack Query и питает индикатор статуса аутентификации в шапке.
 - На все XHR ставится `X-Requested-With: XMLHttpRequest` (belt-and-braces), но серверный шлюз решает по path.
 
-Поскольку SPA всегда трактует `401` как «сессия истекла, делай full-page bounce», backend **обязан** возвращать JSON `401` для XHR — никогда cross-origin `302` на Keycloak. `302` был бы молча пройден `fetch`-ем (default `redirect: 'follow'`), cross-origin preflight на Keycloak зафейлил бы CORS, и XHR упал бы с `TypeError: Failed to fetch`.
+Поскольку как минимум один из этих handler'ов (data-XHR `fetchApi`) слепо доверяет `401` и трактует его как «сессия истекла, делай full-page bounce», backend **обязан** возвращать JSON `401` для XHR — никогда cross-origin `302` на Keycloak. `302` был бы молча пройден `fetch`-ем (default `redirect: 'follow'`), cross-origin preflight на Keycloak зафейлил бы CORS, и XHR упал бы с `TypeError: Failed to fetch`.
 
 ### 1bis.4 За что отвечает backend
 
@@ -355,8 +357,11 @@ class ApiClientAuthorizationFailureFilter(
 
 Стартовое состояние: пользователь залогинен, серверная сессия портала валидна, но OAuth2 refresh не получается (SSO-сессия Keycloak убита, refresh token истёк и т.п.).
 
-- **Browser navigation** на `/components`: SPA bootstrap загружается, в какой-то момент chain поднимает `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` видит non-API path и пробрасывает дальше, `OAuth2AuthorizationRequestRedirectWebFilter` отдаёт full-page `302` на OIDC → свежий логин в Keycloak → пользователь возвращается на исходный путь. UX как у DMS-UI.
-- **XHR** на `/rest/api/4/components` или `/auth/me`: `TokenRelay` бросает эксепшн внутри реактивной цепочки, `ApiClientAuthorizationFailureFilter` матчит path и пишет JSON `401`, SPA-handler в `api.ts` делает `window.location.assign('/oauth2/authorization/keycloak')` из JS, пользователь попадает на свежий OIDC-флоу на верхнем уровне. **Никаких CORS-ошибок, никакого `Failed to fetch`.**
+- **Browser navigation на SPA-путь** (`/`, `/components`, `/components/:id` и т.п.): SCG `TokenRelay` бежит только на routed-путях (`/rest/**`, `/auth/**`), поэтому навигация на SPA-путь никогда не доходит до места, где может подняться `ClientAuthorizationRequiredException` — session cookie портала всё ещё валидна, security chain пропускает запрос, и SPA shell отдаётся (`200 OK` от `SpaFallbackFilter`). Пользователь не замечает проблемы, пока SPA не загрузится и не начнёт XHR.
+- **Data XHR** (`/rest/api/4/components`, `/rest/api/4/owners` и т.п.): `TokenRelay` поднимает `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` матчит path и пишет JSON `401`, `api.ts::fetchApi` видит 401 и сразу делает `window.location.assign('/oauth2/authorization/keycloak')` из JS — пользователь попадает на свежий OIDC-флоу на верхнем уровне. **Никаких CORS-ошибок, никакого `Failed to fetch`.**
+- **`/auth/me`-поллинг**: тот же backend-путь — JSON `401` от фильтра — но `auth.ts::fetchCurrentUser` трактует 401 как «logged out» и возвращает `null` вместо bounce'а. На permission-gated роутах (`/audit`, `/admin`) `RequirePermission` затем дергает тот же `window.location.assign(...)` через `useEffect`, как только видит `user == null`. На незащищённых роутах (`/components` и т.п.) bounce инициирует ближайший data XHR — обычно TanStack Query refetch в течение секунд.
+
+`else Mono.error(ex)` ветка фильтра (rethrow для non-API путей) присутствует как defensive correctness — если когда-нибудь в будущем какой-то другой filter chain поднимет `ClientAuthorizationRequiredException` для non-routed пути, browser-навигация всё равно получит дефолтный 302 на OIDC. В текущей конфигурации этого BFF rethrow-ветка не отрабатывает на реальном трафике, потому что TokenRelay — единственный источник этого эксепшна, и работает он только на `/rest/**` и `/auth/**`.
 
 ## 2. Api-Gateway service
 
@@ -1279,9 +1284,9 @@ Spring Security не синхронизирует logout между прилож
 
 DMS-UI и `api-gateway` технически имеют тот же gap, но он невидим их пользователям:
 
-- Frontend DMS-UI на failed XHR показывает только error toast; пользователи жмут refresh, top-level GET на `/` триггерит `302`, full-page Keycloak login, всё ок. Менее polished, но не сломано.
+- Frontend DMS-UI на failed XHR показывает только error toast; автоматического восстановления у пользователя нет. Восстановление происходит окольно — явный logout, истечение Spring-сессии и последующий 302 на анонимного, или закрытие вкладки — ни один из этих путей не предъявлен пользователю как «сделай это сейчас». Менее polished, но не активно сломано: ни один компонент SPA не зависит от регулярно успешного XHR.
 - `api-gateway` отдаёт только HTML-страницы навигации, без XHR — этот сценарий не возникает.
 
-Для BFF под SPA это уже неприемлемо. Components Management Portal решает это паттерном из раздела 1bis: path-aware authentication entry point + inner `WebFilter`, который перехватывает `ClientAuthorizationRequiredException` для API/XHR путей и конвертирует её в JSON `401`, который SPA-handler в `api.ts` превращает в top-level navigation на `/oauth2/authorization/keycloak`. Browser-навигация на том же BFF продолжает получать default `302`, так что легитимный full-page flow не меняется.
+Для BFF под SPA это уже неприемлемо. Components Management Portal решает это паттерном из раздела 1bis: path-aware authentication entry point + inner `WebFilter`, который перехватывает `ClientAuthorizationRequiredException` для API/XHR путей и конвертирует её в JSON `401`. Bounce из JS дальше делает сам SPA — `api.ts::fetchApi` отправляет навигацию напрямую для data XHR, а `auth.ts::fetchCurrentUser` возвращает `null` и оставляет триггерить bounce за `RequirePermission` (или ближайшим data XHR) для `/auth/me`-поллинга — выводя пользователя на свежий top-level OIDC-флоу. Browser-навигация на том же BFF продолжает получать дефолтный `302` от нетронутого anonymous entry point, так что легитимный full-page flow для unauthenticated юзеров не меняется.
 
 Если в будущем DMS-UI обзаведётся SPA-style XHR-поллингом, паттерн стоит backportить.

--- a/doc/RM Services Security Model (RU).md
+++ b/doc/RM Services Security Model (RU).md
@@ -107,7 +107,7 @@ Repository: `https://github.com/octopusden/octopus-dms-ui`
 .csrf { it.disable() }
 ```
 
-> **Замечание**: эта минимальная конфигурация предполагает, что единственный сценарий неуспеха аутентификации — full-page редирект на OIDC. Для BFF, обслуживающих SPA по XHR (см. раздел 1bis), нужен дополнительный перехватчик `ClientAuthorizationRequiredException` — иначе валидная сессия с непродлеваемым токеном даст cross-origin `302` на Keycloak, и XHR молча упадёт с CORS-ошибкой.
+> **Замечание**: эта минимальная конфигурация предполагает, что единственный сценарий неуспеха аутентификации — full-page редирект на OIDC. Для BFF, обслуживающих SPA по XHR (см. раздел 1bis), нужны **оба** компонента — path-aware authentication entry point и inner-фильтр `ClientAuthorizationRequiredException` — иначе unauthenticated XHR (нет сессии) или authenticated-сессия с непродлеваемым токеном дадут `302` на Keycloak, `fetch()` пойдёт за этим Location cross-origin, и XHR молча упадёт с CORS-ошибкой.
 
 ### 1.5 User flow c примерами кода
 
@@ -293,7 +293,7 @@ Repository: `https://github.com/octopusden/octopus-components-management-portal`
 - `frontend/src/hooks/useCurrentUser.ts` поллит `/auth/me` через TanStack Query и питает индикатор статуса аутентификации в шапке.
 - На все XHR ставится `X-Requested-With: XMLHttpRequest` (belt-and-braces), но серверный шлюз решает по path.
 
-Поскольку как минимум один из этих handler'ов (data-XHR `fetchApi`) слепо доверяет `401` и трактует его как «сессия истекла, делай full-page bounce», backend **обязан** возвращать JSON `401` для XHR — никогда cross-origin `302` на Keycloak. `302` был бы молча пройден `fetch`-ем (default `redirect: 'follow'`), cross-origin preflight на Keycloak зафейлил бы CORS, и XHR упал бы с `TypeError: Failed to fetch`.
+Поскольку как минимум один из этих handler'ов (data-XHR `fetchApi`) слепо доверяет `401` и трактует его как «сессия истекла, делай full-page bounce», backend **обязан** возвращать JSON `401` для XHR — никогда `302`, у которого Location ведёт cross-origin на Keycloak. Такой `302` был бы молча пройден `fetch`-ем (default `redirect: 'follow'`), cross-origin preflight на Keycloak зафейлил бы CORS, и XHR упал бы с `TypeError: Failed to fetch`.
 
 ### 1bis.4 За что отвечает backend
 

--- a/doc/RM Services Security Model (RU).md
+++ b/doc/RM Services Security Model (RU).md
@@ -8,6 +8,13 @@
    3. За что отвечает frontend
    4. За что отвечает backend
    5. User flow c примерами кода
+1bis. `Components Management Portal` service (BFF под SPA с XHR-aware аутентификацией)
+   1. Versions
+   2. Описание
+   3. За что отвечает frontend
+   4. За что отвечает backend
+   5. Зачем нужен дополнительный фильтр
+   6. User flow при провале token refresh
 2. `Api-Gateway` service
    1. Versions
    2. Описание
@@ -20,6 +27,7 @@
    4. Как библиотека подключается и используется в других сервисах
 4. Q&A
    1. Почему когда выполняем логаут в dms-ui, то в api-gateway тоже происходит логаут, и наоборот
+   2. Почему для BFF под SPA нельзя ограничиться тем же простым `oauth2Login`, что в DMS-UI
 
 ![](communication_diagram.png)
 
@@ -98,6 +106,8 @@ Repository: `https://github.com/octopusden/octopus-dms-ui`
 // Отключаем Cross-Site Request Forgery (защиту от межсайтового доступа)
 .csrf { it.disable() }
 ```
+
+> **Замечание**: эта минимальная конфигурация предполагает, что единственный сценарий неуспеха аутентификации — full-page редирект на OIDC. Для BFF, обслуживающих SPA по XHR (см. раздел 1bis), нужен дополнительный перехватчик `ClientAuthorizationRequiredException` — иначе валидная сессия с непродлеваемым токеном даст cross-origin `302` на Keycloak, и XHR молча упадёт с CORS-ошибкой.
 
 ### 1.5 User flow c примерами кода
 
@@ -255,6 +265,98 @@ dms-ui.hostname: <host_name>
 ```yaml
 dms-ui.hostname: <host_name>
 ```
+
+## 1bis. Components Management Portal service (BFF под SPA с XHR-aware аутентификацией)
+
+Repository: `https://github.com/octopusden/octopus-components-management-portal`
+
+`Components Management Portal` использует тот же BFF-паттерн, что и DMS-UI (OAuth2 login, серверная сессия, `TokenRelay` проксирует запросы к downstream-сервису — в данном случае Components Registry Service). Отличие — на стороне frontend'а: SPA портала периодически делает XHR на `/auth/me` и фоновые refetch'и данных с предположением, что просроченная сессия отвечает **JSON 401** (а не `302` на OIDC). Это предположение и формирует требования к backend'у.
+
+### 1bis.1 Versions
+
+- JDK 21
+- Kotlin 1.9.25
+- Gradle 8.14.4
+- Spring Boot 3.2.2
+- Spring Cloud 2023.0.1
+
+### 1bis.2 Описание
+
+`octopus-components-management-portal` — это Spring Boot WebFlux + Spring Cloud Gateway BFF, который аутентифицирует браузер через OIDC, хранит access token в серверной сессии и через `TokenRelay` подкладывает его как `Authorization: Bearer <token>` при проксировании `/rest/**` и `/auth/**` в registry service. Дополнительно отдаёт собранный Vite SPA на React из `/static/`.
+
+### 1bis.3 За что отвечает frontend
+
+- SPA не видит сырых токенов; аутентификация — серверная session cookie + double-submit CSRF (cookie доступна SPA, отдаётся обратно в `X-XSRF-TOKEN`).
+- `frontend/src/lib/api.ts` отправляет все XHR через тонкий wrapper `fetchApi`. На `response.status === 401` инициирует full-page navigation на `/oauth2/authorization/keycloak` для свежего OIDC-флоу.
+- `frontend/src/hooks/useCurrentUser.ts` дёргает `/auth/me` через TanStack Query; результат рисует индикатор статуса аутентификации в шапке.
+- На все XHR ставится `X-Requested-With: XMLHttpRequest` (belt-and-braces), но серверный шлюз решает по path.
+
+Поскольку SPA всегда трактует `401` как «сессия истекла, делай full-page bounce», backend **обязан** возвращать JSON `401` для XHR — никогда cross-origin `302` на Keycloak. `302` был бы молча пройден `fetch`-ем (default `redirect: 'follow'`), cross-origin preflight на Keycloak зафейлил бы CORS, и XHR упал бы с `TypeError: Failed to fetch`.
+
+### 1bis.4 За что отвечает backend
+
+`SecurityConfig.kt` разводит entry point так, чтобы API/XHR вызовы и browser-навигация получали разные ответы на одно и то же «не авторизован»:
+
+```kotlin
+val apiMatcher: ServerWebExchangeMatcher = pathMatchers("/rest/**", "/auth/**")
+val apiEntryPoint =
+    ServerAuthenticationEntryPoint { exchange, _ ->
+        apiJson401Writer.write(exchange, ApiJson401Reason.UNAUTHENTICATED)
+    }
+val browserEntryPoint =
+    RedirectServerAuthenticationEntryPoint("/oauth2/authorization/$OIDC_REGISTRATION_ID")
+val delegatingEntryPoint =
+    DelegatingServerAuthenticationEntryPoint(
+        DelegateEntry(apiMatcher, apiEntryPoint),
+        DelegateEntry(ServerWebExchangeMatchers.anyExchange(), browserEntryPoint),
+    )
+
+http
+    .authorizeExchange { /* ... */ }
+    .oauth2Login(Customizer.withDefaults())
+    .exceptionHandling { it.authenticationEntryPoint(delegatingEntryPoint) }
+    // см. 1bis.5 ниже — зачем нужен этот фильтр
+    .addFilterAfter(
+        ApiClientAuthorizationFailureFilter(apiMatcher, apiJson401Writer),
+        SecurityWebFiltersOrder.OAUTH2_AUTHORIZATION_CODE,
+    )
+    /* ... */
+```
+
+`ApiJson401Writer` — это shared `@Component`, который пишет JSON 401 фиксированной формы (`{"error":"<reason>"}`) с reason-текстом из enum `ApiJson401Reason` — никаких произвольных exception messages в body. И entry point, и фильтр (см. ниже) проходят через него, так что anonymous- и refresh-failed-пути неотличимы для клиента.
+
+### 1bis.5 Зачем нужен дополнительный фильтр
+
+`DelegatingServerAuthenticationEntryPoint` корректно покрывает случай «запрос без аутентификации». Он **не** покрывает случай, когда пользователь *аутентифицирован* (валидная сессия, валидный `OAuth2AuthenticationToken`), но OAuth2 access token нельзя обновить — например потому что SSO-сессия была убита logout'ом из соседнего клиента (см. Q&A 4.1).
+
+Этот провал всплывает в Spring Cloud Gateway `TokenRelayGatewayFilterFactory` как `ClientAuthorizationRequiredException`. По умолчанию его ловит `OAuth2AuthorizationRequestRedirectWebFilter` (зарегистрированный `oauth2Login()` на позиции `SecurityWebFiltersOrder.HTTP_BASIC`) и отправляет `302` на `/oauth2/authorization/keycloak`. Для browser-навигации это правильный UX. Для XHR — это и есть баг из 1bis.3: браузер молча идёт за редиректом, попадает на cross-origin Keycloak preflight, и XHR падает с CORS-ошибкой.
+
+`ApiClientAuthorizationFailureFilter` перехватывает этот эксепшн для `/rest/**` + `/auth/**` путей и проводит ответ через `ApiJson401Writer`. Он должен сидеть INNER относительно `OAuth2AuthorizationRequestRedirectWebFilter`, чтобы ошибка прилетала к нему первым; этого добивается `addFilterAfter(filter, SecurityWebFiltersOrder.OAUTH2_AUTHORIZATION_CODE)` — «after» ставит фильтр на бо́льший order и, соответственно, глубже в цепочке.
+
+```kotlin
+class ApiClientAuthorizationFailureFilter(
+    private val apiMatcher: ServerWebExchangeMatcher,
+    private val writer: ApiJson401Writer,
+) : WebFilter {
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        chain.filter(exchange).onErrorResume(ClientAuthorizationRequiredException::class.java) { ex ->
+            apiMatcher.matches(exchange).flatMap { match ->
+                if (match.isMatch) {
+                    writer.write(exchange, ApiJson401Reason.AUTHORIZATION_EXPIRED)
+                } else {
+                    Mono.error(ex)  // re-emit, чтобы default redirect filter обрабатывал browser-навигацию как раньше
+                }
+            }
+        }
+}
+```
+
+### 1bis.6 User flow при провале token refresh
+
+Стартовое состояние: пользователь залогинен, серверная сессия портала валидна, но OAuth2 refresh не получается (SSO-сессия Keycloak убита, refresh token истёк и т.п.).
+
+- **Browser navigation** на `/components`: SPA bootstrap загружается, в какой-то момент chain поднимает `ClientAuthorizationRequiredException`, `ApiClientAuthorizationFailureFilter` видит non-API path и пробрасывает дальше, `OAuth2AuthorizationRequestRedirectWebFilter` отдаёт full-page `302` на OIDC → свежий логин в Keycloak → пользователь возвращается на исходный путь. UX как у DMS-UI.
+- **XHR** на `/rest/api/4/components` или `/auth/me`: `TokenRelay` бросает эксепшн внутри реактивной цепочки, `ApiClientAuthorizationFailureFilter` матчит path и пишет JSON `401`, SPA-handler в `api.ts` делает `window.location.assign('/oauth2/authorization/keycloak')` из JS, пользователь попадает на свежий OIDC-флоу на верхнем уровне. **Никаких CORS-ошибок, никакого `Failed to fetch`.**
 
 ## 2. Api-Gateway service
 
@@ -1161,3 +1263,25 @@ Spring Security не синхронизирует logout между прилож
 - при повторном OAuth2 Login
 
 То есть, logout в одном клиенте `не отзывает access tokens`, уже выданные другим клиентам. Они остаются валидными Spring-ом до истечения срока жизни, но не могут быть обновлены без новой SSO-сессии.
+
+### 4.2 Почему для BFF под SPA нельзя ограничиться тем же простым `oauth2Login`, что в DMS-UI
+
+Когда BFF обслуживает только full-page навигацию (DMS-UI сегодня, `api-gateway` всегда), `oauth2Login(Customizer.withDefaults())` достаточно: любой провал аутентификации превращается в `302` на OIDC authorization endpoint, и браузер обрабатывает его как обычный top-level редирект — рендерится форма логина Keycloak, пользователь логинится, Spring Security завершает authorization-code flow.
+
+Картинка меняется, как только BFF начинает обслуживать SPA, делающую фоновые XHR на `/auth/me`-поллинг и refetch'и данных (паттерн Components Management Portal — см. раздел 1bis). Спустя время бездействия аутентифицированная сессия с непродлеваемым токеном (типично — потому что SSO-сессия была убита logout'ом из соседнего клиента, см. 4.1) поднимает `ClientAuthorizationRequiredException` в `TokenRelayGatewayFilterFactory`. Default Spring Security: `OAuth2AuthorizationRequestRedirectWebFilter` ловит её и отвечает `302 Location: <Keycloak>/realms/.../protocol/openid-connect/auth?response_type=code&...`.
+
+Для full-page навигации идеально — браузер показывает форму логина. Для XHR — поломка:
+
+1. `fetch()` по умолчанию `redirect: 'follow'`, поэтому браузер молча идёт за cross-origin редиректом на Keycloak.
+2. Cross-origin XHR триггерит CORS preflight (`OPTIONS`) на хост Keycloak.
+3. Authorization endpoint Keycloak не предназначен для XHR и не отдаёт permissive CORS headers под наш origin — даже если бы отдавал, его response это HTML-форма, а не JSON.
+4. Preflight отклоняется → исходный `fetch` reject'ится с `TypeError: Failed to fetch` → SPA показывает generic ошибку, пользователь застревает.
+
+DMS-UI и `api-gateway` технически имеют тот же gap, но он невидим их пользователям:
+
+- Frontend DMS-UI на failed XHR показывает только error toast; пользователи жмут refresh, top-level GET на `/` триггерит `302`, full-page Keycloak login, всё ок. Менее polished, но не сломано.
+- `api-gateway` отдаёт только HTML-страницы навигации, без XHR — этот сценарий не возникает.
+
+Для BFF под SPA это уже неприемлемо. Components Management Portal решает это паттерном из раздела 1bis: path-aware authentication entry point + inner `WebFilter`, который перехватывает `ClientAuthorizationRequiredException` для API/XHR путей и конвертирует её в JSON `401`, который SPA-handler в `api.ts` превращает в top-level navigation на `/oauth2/authorization/keycloak`. Browser-навигация на том же BFF продолжает получать default `302`, так что легитимный full-page flow не меняется.
+
+Если в будущем DMS-UI обзаведётся SPA-style XHR-поллингом, паттерн стоит backportить.


### PR DESCRIPTION
## Summary

- Adds a new section `1bis. Components Management Portal service (BFF for SPA with XHR-aware auth)` between DMS-UI and Api-Gateway in `RM Services Security Model`. Mirrors the structure of the DMS-UI section: versions, description, frontend/backend responsibilities, code excerpts, user flow.
- Adds a companion Q&A `4.2 Why a SPA-driven BFF cannot use the same simple oauth2Login as DMS-UI` explaining why the simple `oauth2Login(Customizer.withDefaults())` pattern that works for DMS-UI and api-gateway breaks when the BFF starts serving an SPA with background XHR polling — and how the portal solves it.
- Adds a one-line note at end of section 1.4 (DMS-UI Backend responsibilities) pointing readers at 1bis when their service starts serving XHR.
- EN and RU files updated synchronously.

Implementation that this doc describes landed in [octopusden/octopus-components-management-portal#27](https://github.com/octopusden/octopus-components-management-portal/pull/27) (commit `c04e16e`). Code excerpts in section 1bis are faithful elisions of the actual `SecurityConfig.kt` and `ApiClientAuthorizationFailureFilter.kt`.

## Test plan

- [x] Markdown renders cleanly in GitHub preview (no broken code fences, TOC entries match section structure).
- [x] Cross-links: section 1.4 → 1bis, Q&A 4.2 → 1bis + 4.1, section 1bis.5 → Q&A 4.1.
- [x] Code excerpts compared against actual portal repo files (no drift).
- [x] EN/RU structural parity (same subsections, same code blocks).
- [x] Independent technical review (Sonnet) — verdict: ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new SPA-oriented BFF pattern describing XHR-aware authentication for the Components Management Portal.
  * Clarified that API/XHR calls should receive JSON 401 on auth expiry while full-page navigations keep redirect-based OIDC flows.
  * Noted that simple oauth2Login setups are insufficient for SPA XHR scenarios and provided mitigation guidance.
  * Expanded Q&A on token lifetime, logout behavior, and XHR failure/recovery scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/octopusden/octopus-api-gateway/pull/29)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->